### PR TITLE
Fix invalid CoAP type range check

### DIFF
--- a/iCoAP-Library_Files/ICoAPExchange.m
+++ b/iCoAP-Library_Files/ICoAPExchange.m
@@ -107,7 +107,7 @@
     
     //Check Version and type (first 4 bits)
     cO.type = strtol([[hexString substringWithRange:NSMakeRange(0, 1)] UTF8String], NULL, 16);
-    if (IC_CONFIRMABLE < cO.type > IC_RESET) {
+    if (cO.type < IC_CONFIRMABLE || cO.type > IC_RESET) {
         return nil;
     }
     

--- a/iCoAP_Example/iCoAP_Example/ICoAPExchange.m
+++ b/iCoAP_Example/iCoAP_Example/ICoAPExchange.m
@@ -107,7 +107,7 @@
     
     //Check Version and type (first 4 bits)
     cO.type = strtol([[hexString substringWithRange:NSMakeRange(0, 1)] UTF8String], NULL, 16);
-    if (IC_CONFIRMABLE < cO.type > IC_RESET) {
+    if (cO.type < IC_CONFIRMABLE || cO.type > IC_RESET) {
         return nil;
     }
     


### PR DESCRIPTION
## Summary

This PR fixes an invalid chained comparison in `ICoAPExchange.m`:

```objc
if (IC_CONFIRMABLE < cO.type > IC_RESET)
```

This expression is not valid for the intended range check and can fail to compile with newer
Xcode versions, starting from Xcode 26.4.

## What changed
Replaced the invalid comparison with an explicit bounds check:

```objc
if (cO.type < IC_CONFIRMABLE || cO.type > IC_RESET)
```

This preserves the intended behavior: rejecting decoded messages whose type is outside the valid ICoAPType range (IC_CONFIRMABLE through IC_RESET).

## Files updated
- iCoAP-Library_Files/ICoAPExchange.m
- iCoAP_Example/iCoAP_Example/ICoAPExchange.m